### PR TITLE
Octane emission bug 1

### DIFF
--- a/packages/contracts/contracts/ActivePool.sol
+++ b/packages/contracts/contracts/ActivePool.sol
@@ -93,13 +93,13 @@ contract ActivePool is Ownable, CheckContract, IActivePool {
     function increaseLUSDDebt(uint _amount) external override {
         _requireCallerIsBOorTroveM();
         LUSDDebt  = LUSDDebt.add(_amount);
-        ActivePoolLUSDDebtUpdated(LUSDDebt);
+        emit ActivePoolLUSDDebtUpdated(LUSDDebt);
     }
 
     function decreaseLUSDDebt(uint _amount) external override {
         _requireCallerIsBOorTroveMorSP();
         LUSDDebt = LUSDDebt.sub(_amount);
-        ActivePoolLUSDDebtUpdated(LUSDDebt);
+        emit ActivePoolLUSDDebtUpdated(LUSDDebt);
     }
 
     // --- 'require' functions ---

--- a/packages/contracts/contracts/SortedTroves.sol
+++ b/packages/contracts/contracts/SortedTroves.sol
@@ -198,7 +198,7 @@ contract SortedTroves is Ownable, CheckContract, ISortedTroves {
 
         delete data.nodes[_id];
         data.size = data.size.sub(1);
-        NodeRemoved(_id);
+        emit NodeRemoved(_id);
     }
 
     /*


### PR DESCRIPTION
# Missing 'emit' for event emission in ActivePool.sol

**Summary:** ActivePool.sol emits the ActivePoolLUSDDebtUpdated event without the required 'emit' keyword in increaseLUSDDebt and decreaseLUSDDebt under Solidity 0.6.11, causing a compile-time error that blocks deployment/upgrade. No runtime or user fund impact exists.

# Missing emit for NodeRemoved event in SortedTroves._remove 

**Summary:** In SortedTroves.sol (Solidity 0.6.11), the NodeRemoved event is invoked without the emit keyword in _remove(), which is invalid in Solidity >=0.5.0 and prevents compilation/deployment. This is a development-time correctness issue with no runtime exploitability.

<img width="132" height="58" alt="Screenshot 2025-09-01 at 2 01 30 PM" src="https://github.com/user-attachments/assets/21e17723-d88d-4204-8f62-c96fcad4b275" /> [Octane Security](https://octane.security)